### PR TITLE
Fix #1 - Test failing during Maven build

### DIFF
--- a/src/main/java/hu/bme/mit/spaceship/GT4500.java
+++ b/src/main/java/hu/bme/mit/spaceship/GT4500.java
@@ -79,6 +79,15 @@ public class GT4500 implements SpaceShip {
       case ALL:
         // try to fire both of the torpedo stores
         //TODO implement feature
+	if(! primaryTorpedoStore.isEmpty()) {
+	  firingSuccess = primaryTorpedoStore.fire(1);
+	 wasPrimaryFiredLast = true;
+	}
+
+	if(! secondaryTorpedoStore.isEmpty()) {
+	  firingSuccess = secondaryTorpedoStore.fire(1);
+	  wasPrimaryFiredLast = false;
+	}
 
         break;
     }


### PR DESCRIPTION
The previous Maven build failed with the following test error: 

`org.opentest4j.AssertionFailedError: expected: <true> but was: <false> at hu.bme.mit.spaceship.GT4500Test.fireTorpedo_All_Success(GT4500Test.java:37)`

To fix this issue, I implemented the 'ALL' firing mode in `GT4500.java`